### PR TITLE
[BUGFIX]  Semicolon correction

### DIFF
--- a/mage2gen/snippets/payment.py
+++ b/mage2gen/snippets/payment.py
@@ -46,7 +46,7 @@ class PaymentSnippet(Snippet):
 			params=[
 				'\\Magento\\Quote\\Api\\Data\\CartInterface $quote = null'
 			],
-			body="return parent::isAvailable($quote)"
+			body="return parent::isAvailable($quote);"
 		))
 	
 		self.add_class(payment_class)

--- a/mage2gen/snippets/payment.py
+++ b/mage2gen/snippets/payment.py
@@ -46,7 +46,7 @@ class PaymentSnippet(Snippet):
 			params=[
 				'\\Magento\\Quote\\Api\\Data\\CartInterface $quote = null'
 			],
-			body="return parent::isAvailable($quote);"
+			body="return parent::isAvailable($quote);" 
 		))
 	
 		self.add_class(payment_class)


### PR DESCRIPTION
When create a payments module, the isAvailable method not contains semicolon.

