### PR TITLE
[TASK] Add python 3.6 to travis testing suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ language: python
 addons:
   apt:
     packages:
-    - php5-cli
+      - php5-cli
 
 python:
   - 3.4
   - 3.5
+  - 3.6
 
 before_install:
   - "curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar"


### PR DESCRIPTION
Python 3.6 has been released. We should add it to the Travis test-suite.