### PR TITLE
Virtual product type has been added into the product attribute snippet

### DIFF
--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -68,7 +68,8 @@ class ProductAttributeSnippet(Snippet):
 		("simple","Simple Products"),
 		("grouped","Grouped Products"),
 		("bundle","Bundled Products"),
-		("configurable","Configurable Products")
+		("configurable","Configurable Products"),
+		("virtual","Virtual Products")		
 	]
 
 	description = """


### PR DESCRIPTION
Now the product attributes could be applied to the Virtual Magento product as mentioned at https://github.com/krukas/Mage2Gen/issues/94