### PR TITLE
[BUGFIX] [issue-178] Allow dots in the Block Reference Name

### DIFF
--- a/mage2gen/snippets/block.py
+++ b/mage2gen/snippets/block.py
@@ -145,7 +145,7 @@ class BlockSnippet(Snippet):
 			SnippetParam(name='reference_name',
 						 description='Example: content',
 						 depend={'layout_handle': r'^\w+$'},
-						 regex_validator=r'^\w+$',
-						 error_message='Only alphanumeric and underscore characters are allowed'),
+						 regex_validator=r'^[\w.]+$',
+						 error_message='Only alphanumeric, dots and underscore characters are allowed'),
 		]
 		


### PR DESCRIPTION
This is related to issue #178