### PR TITLE
[TASK] [issue-176] Change Model Admin Edit Form Title which doesn't depend on $model->getTitle()

### DIFF
--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -875,7 +875,7 @@ class ModelSnippet(Snippet):
 				    $id ? __('Edit {model_name}') : __('New {model_name}')
 				);
 				$resultPage->getConfig()->getTitle()->prepend(__('{model_name}s'));
-				$resultPage->getConfig()->getTitle()->prepend($model->getId() ? $model->getTitle() : __('New {model_name}'));
+				$resultPage->getConfig()->getTitle()->prepend($model->getId() ? __('Edit {model_name} %1', $model->getId()) : __('New {model_name}'));
 				return $resultPage;""".format(
 						model_id = model_id,
 						model_class = model_class.class_namespace,


### PR DESCRIPTION
### Description
When editing a existing record the title depends on $model->getTitle(). Replace with __('Edit {model_name}')

### Fixed Issues (if relevant)

**[krukas/Mage2Gen#176](https://github.com/krukas/Mage2Gen/issues/176): Model Admin Edit Form Title**

The title should be changed to 
```
__('Edit {model_name} %1', $model->getId())
```
