### PR TITLE
[TASK] [issue-153] Use DataModels instead of Models for search result…

### DIFF
--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -429,9 +429,9 @@ class ModelSnippet(Snippet):
 					$collection->setPageSize($searchCriteria->getPageSize());
 
 					$items = [];
-					foreach ($collection as $model) {
+					foreach ($collection as $model) {{
 						$items[] = $model->getDataModel();
-					}
+					}}
 					$searchResults->setItems($items);
 					return $searchResults;
 			""".format(variable=model_name_capitalized_after,data_interface=api_data_class.class_namespace,variable_upper=model_name_capitalized),

--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -267,11 +267,6 @@ class ModelSnippet(Snippet):
 				"@param array $data",
 			]
 		))
-		model_class.add_method(Phpmethod('_construct',
-			access=Phpmethod.PROTECTED,
-			body="$this->_init(\{}::class);".format(resource_model_class.class_namespace),
-			docstring=['@return void']))
-
 		model_class.add_method(Phpmethod('getDataModel', access=Phpmethod.PUBLIC,
 			body="""${variable}Data = $this->getData();
 			

--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -192,7 +192,12 @@ class ModelSnippet(Snippet):
 		self.add_class(resource_model_class)
 
 		# Create api data interface class
-		api_data_class =  InterfaceClass('Api\\Data\\' + model_name_capitalized.replace('_', '\\') + 'Interface',attributes=["const {} = '{}';".format(field_name.upper(),field_name),"const {} = '{}';".format(model_id.upper(),model_id)])
+		api_data_class =  InterfaceClass('Api\\Data\\' + model_name_capitalized.replace('_', '\\') + 'Interface',
+			attributes=[
+				"const {} = '{}';".format(field_name.upper(),field_name),
+				"const {} = '{}';".format(model_id.upper(),model_id),
+				"const DATA_MODEL = 'data_model';"
+			])
 
 		api_data_class.add_method(InterfaceMethod('get'+model_id_capitalized,docstring=['Get {}'.format(model_id),'@return {}'.format('string|null')]))
 		self.add_class(api_data_class)
@@ -206,6 +211,11 @@ class ModelSnippet(Snippet):
 		api_data_class.add_method(InterfaceMethod('set'+field_name_capitalized,params=['${}'.format(lowerfirst(field_name_capitalized))],docstring=['Set {}'.format(field_name),'@param string ${}'.format(lowerfirst(field_name_capitalized)),'@return \{}'.format(api_data_class.class_namespace)]))
 		self.add_class(api_data_class)
 
+		api_data_class.add_method(InterfaceMethod('getDataModel',docstring=['Get data model.','@return {}'.format('string|null')]))
+		self.add_class(api_data_class)
+
+		api_data_class.add_method(InterfaceMethod('setDataModel', params=['$dataModel'], docstring=['Set data model.', '@param $dataModel','@return \{}'.format(api_data_class.class_namespace)]))
+		self.add_class(api_data_class)
 
 
 
@@ -289,6 +299,7 @@ class ModelSnippet(Snippet):
 				"@return {}Interface".format(model_name_capitalized),
 			]
 		))
+		model_class.add_method(Phpmethod('setDataModel', docstring=['Set data model.','@param {}Interface $dataModel'.format(model_name_capitalized),'@return \{}'.format(api_data_class.class_namespace)], params=['$dataModel'], access=Phpmethod.PUBLIC, body="return $this->setData(self::DATA_MODEL, $dataModel);"))
 		self.add_class(model_class)
 
 		# Create collection

--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -282,7 +282,7 @@ class ModelSnippet(Snippet):
 			    {variable_upper}Interface::class
 			);
 			
-        	return ${variable}DataObject;
+			return ${variable}DataObject;
 			""".format(variable=model_name.lower(), variable_upper=model_name_capitalized),
 			docstring=[
 				"Retrieve {} model with {} data".format(model_name.lower(), model_name.lower()),
@@ -396,9 +396,9 @@ class ModelSnippet(Snippet):
 		model_repository_class.add_method(Phpmethod('getList', access=Phpmethod.PUBLIC,
 			params=['\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria'],
 			body="""$searchResults = $this->searchResultsFactory->create();
-        			$searchResults->setSearchCriteria($searchCriteria);
-        			
-       				$collection = $this->{variable}CollectionFactory->create();
+			$searchResults->setSearchCriteria($searchCriteria);
+			
+			$collection = $this->{variable}CollectionFactory->create();
 					foreach ($searchCriteria->getFilterGroups() as $filterGroup) {{
 					    $fields = [];
 					    $conditions = [];

--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -192,12 +192,7 @@ class ModelSnippet(Snippet):
 		self.add_class(resource_model_class)
 
 		# Create api data interface class
-		api_data_class =  InterfaceClass('Api\\Data\\' + model_name_capitalized.replace('_', '\\') + 'Interface',
-			attributes=[
-				"const {} = '{}';".format(field_name.upper(),field_name),
-				"const {} = '{}';".format(model_id.upper(),model_id),
-				"const DATA_MODEL = 'data_model';"
-			])
+		api_data_class =  InterfaceClass('Api\\Data\\' + model_name_capitalized.replace('_', '\\') + 'Interface',attributes=["const {} = '{}';".format(field_name.upper(),field_name),"const {} = '{}';".format(model_id.upper(),model_id)])
 
 		api_data_class.add_method(InterfaceMethod('get'+model_id_capitalized,docstring=['Get {}'.format(model_id),'@return {}'.format('string|null')]))
 		self.add_class(api_data_class)
@@ -211,11 +206,6 @@ class ModelSnippet(Snippet):
 		api_data_class.add_method(InterfaceMethod('set'+field_name_capitalized,params=['${}'.format(lowerfirst(field_name_capitalized))],docstring=['Set {}'.format(field_name),'@param string ${}'.format(lowerfirst(field_name_capitalized)),'@return \{}'.format(api_data_class.class_namespace)]))
 		self.add_class(api_data_class)
 
-		api_data_class.add_method(InterfaceMethod('getDataModel',docstring=['Get data model.','@return {}'.format('string|null')]))
-		self.add_class(api_data_class)
-
-		api_data_class.add_method(InterfaceMethod('setDataModel', params=['$dataModel'], docstring=['Set data model.', '@param $dataModel','@return \{}'.format(api_data_class.class_namespace)]))
-		self.add_class(api_data_class)
 
 
 
@@ -299,7 +289,6 @@ class ModelSnippet(Snippet):
 				"@return {}Interface".format(model_name_capitalized),
 			]
 		))
-		model_class.add_method(Phpmethod('setDataModel', docstring=['Set data model.','@param {}Interface $dataModel'.format(model_name_capitalized),'@return \{}'.format(api_data_class.class_namespace)], params=['$dataModel'], access=Phpmethod.PUBLIC, body="return $this->setData(self::DATA_MODEL, $dataModel);"))
 		self.add_class(model_class)
 
 		# Create collection

--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -277,11 +277,11 @@ class ModelSnippet(Snippet):
 			
 			${variable}DataObject = $this->{variable}DataFactory->create();
 			$this->dataObjectHelper->populateWithArray(
-            	${variable}DataObject,
-            	${variable}Data,
-            	{variable_upper}Interface::class
-        	);
-        	
+			    ${variable}DataObject,
+			    ${variable}Data,
+			    {variable_upper}Interface::class
+			);
+			
         	return ${variable}DataObject;
 			""".format(variable=model_name.lower(), variable_upper=model_name_capitalized),
 			docstring=[
@@ -430,9 +430,10 @@ class ModelSnippet(Snippet):
 
 					$items = [];
 					foreach ($collection as $model) {{
-						$items[] = $model->getDataModel();
+					    $items[] = $model->getDataModel();
 					}}
 					$searchResults->setItems($items);
+					
 					return $searchResults;
 			""".format(variable=model_name_capitalized_after,data_interface=api_data_class.class_namespace,variable_upper=model_name_capitalized),
 			docstring=['{@inheritdoc}']


### PR DESCRIPTION
…s items in repositories

### Description
Repositories should be returning DataModels instead of Models in their search results. Magento has been slow to move this way, but it would be nice for Mage2Gen to support this ahead of the curve. An example of Magento doing this: https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php#L373 and https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Customer/Model/Customer.php#L310


### Fixed Issues (if relevant)

**[krukas/Mage2Gen#153](https://github.com/krukas/Mage2Gen/issues/153): Use DataModels instead of Models for search results items in repositories**

+ Implement getDataModel on Model
+ Change applied to getList() on ModelRepository, searchResult items should returns DataModels