### PR TITLE
Add leading slash that was missing in 'extends'

### DIFF
--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -201,7 +201,7 @@ class ProductAttributeSnippet(Snippet):
 
 	def add_source_model(self, attribute_code, options_php_array_string, used_in_product_listing):
 		source_model = Phpclass('Model\\Product\\Attribute\Source\\{}'.format(upperfirst(attribute_code)),
-			extends='Magento\\Eav\\Model\\Entity\\Attribute\\Source\\AbstractSource')
+			extends='\\Magento\\Eav\\Model\\Entity\\Attribute\\Source\\AbstractSource')
 
 		source_model.add_method(Phpmethod(
 			'getAllOptions',


### PR DESCRIPTION
The leading backslash was missing in the extends part, which means that the AbstractSource class is thought to be like: 
`MyVendor\MyModule\Model\Product\Attribute\Source\Magento\Eav\Model\Entity\Attribute\Source\AbstractSource`