### PR TITLE
[TASK] [issue-223] Fix Magento 2.2, 2.3 inline edit on wrong node text

### DIFF
--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -552,8 +552,8 @@ class ModelSnippet(Snippet):
 				]),
 				Xmlnode('childDefaults', nodes=[
 					Xmlnode('param', attributes={'name': 'fieldAction', 'xsi:type': 'array'}, nodes=[
-						Xmlnode('item', attributes={'name': 'provider', 'xsi:type': 'string'}, node_text='{0}_listing.{0}_listing.{0}_columns.actions'.format(model_table)),
-						Xmlnode('item', attributes={'name': 'target', 'xsi:type': 'string'}, node_text='applyAction'),
+						Xmlnode('item', attributes={'name': 'provider', 'xsi:type': 'string'}, node_text='{0}_listing.{0}_listing.{0}_columns_editor'.format(model_table)),
+						Xmlnode('item', attributes={'name': 'target', 'xsi:type': 'string'}, node_text='startEdit'),
 						Xmlnode('item', attributes={'name': 'params', 'xsi:type': 'array'}, nodes=[
 							Xmlnode('item', attributes={'name': '0', 'xsi:type': 'string'}, node_text='${ $.$data.rowIndex }'),
 							Xmlnode('item', attributes={'name': '1', 'xsi:type': 'boolean'}, node_text='true'),


### PR DESCRIPTION
### Description
Inline editing for a UI grid component does not work when selection M2.2 module.

If you change two lines, it does:

```
<settings>
	<editorConfig>
		<param name="selectProvider" xsi:type="string">listing.listing.columns.ids</param>
		<param name="enabled" xsi:type="boolean">true</param>
		<param name="indexField" xsi:type="string">id_filed</param>
		<param name="clientConfig" xsi:type="array">
			<item name="saveUrl" path="icrm_report/budgetfigure/inlineEdit" xsi:type="url"/>
			<item name="validateBeforeSave" xsi:type="boolean">false</item>
		</param>
	</editorConfig>
	<childDefaults>
		<param name="fieldAction" xsi:type="array">
			---<item name="provider" xsi:type="string">listing.listing.columns_editor</item>
			+++<item name="provider" xsi:type="string">listing.ilisting.columns.actions</item>
			---<item name="target" xsi:type="string">applyAction</item>
			+++<item name="target" xsi:type="string">startEdit</item>
			<item name="params" xsi:type="array">
				<item name="0" xsi:type="string">${ $.$data.rowIndex }</item>
				<item name="1" xsi:type="boolean">true</item>
			</item>
		</param>
	</childDefaults>
</settings>
```

### Fixed Issues (if relevant)

**[krukas/Mage2Gen#223](https://github.com/krukas/Mage2Gen/issues/223): Magento 2.2 inline edit**

+ Change Xmlnode: provider. See https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_listing.xml#L129
+ Change Xmlnode: target. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_listing.xml#L130