### PR TITLE
[TASK] [PATCH] Add swatch types for product attributes

### DIFF
--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -114,6 +114,10 @@ class ProductAttributeSnippet(Snippet):
 		with open(templatePath, 'rb') as tmpl:
 			template = tmpl.read().decode('utf-8')
 
+		split_attribute_code = attribute_code.split('_')
+		attribute_code_capitalized = ''.join(upperfirst(item) for item in split_attribute_code)
+		attribute_code_capitalized_after = attribute_code_capitalized[0].lower() + attribute_code_capitalized[1:]
+
 		is_swatch_option = frontend_input == 'swatch_visual' or frontend_input == 'swatch_text'
 
 		if frontend_input == 'swatch_visual':
@@ -143,7 +147,7 @@ class ProductAttributeSnippet(Snippet):
 			apply_to = apply_to,
 			backend = 'Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend' if frontend_input == 'multiselect' else '',
 			source_model = source_model,
-			call_convert_method = '$this->convert' + upperfirst(attribute_code) + 'ToSwatches();' if is_swatch_option else ''
+			call_convert_method = '$this->convert' + attribute_code_capitalized + 'ToSwatches();' if is_swatch_option else ''
 		)
 
 		setupType = 'Install'
@@ -232,7 +236,7 @@ class ProductAttributeSnippet(Snippet):
 
 		if is_swatch_option:
 			install_data.add_method(Phpmethod(
-				'convert{}ToSwatches'.format(upperfirst(attribute_code)),
+				'convert{}ToSwatches'.format(attribute_code_capitalized),
 				body="""$attribute = $this->eavConfig->getAttribute('catalog_product', '{attribute_code}');
 				if (!$attribute) {{
 				    return;

--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -30,11 +30,11 @@ class ProductAttributeSnippet(Snippet):
 		("multiselect","Multiple Select"),
 		("select","Dropdown"),
 		("price","Price"),
-		("static","Static")
+		("static","Static"),
 		#("media_image","Media Image"),
 		#("weee","Fixed Product Tax"),
-		#("swatch_visual","Visual Swatch"),
-		#("swatch_text","Text Swatch")
+		("swatch_visual","Visual Swatch"),
+		("swatch_text","Text Swatch")
 	]
 
 	STATIC_FIELD_TYPES = [
@@ -54,8 +54,8 @@ class ProductAttributeSnippet(Snippet):
 		"price":"decimal",
 		#"media_image":"",
 		#"weee":"",
-		#"swatch_visual":"",
-		#"swatch_text":""
+		"swatch_visual":"int",
+		"swatch_text":"int"
 	}
 
 	SCOPE_CHOICES = [
@@ -92,7 +92,7 @@ class ProductAttributeSnippet(Snippet):
 		user_defined = 'true'
 		options = options.split(',') if options else []
 		options_php_array = '"'+'","'.join(x.strip() for x in options) + '"'
-		options_php_array_string = "array('values' => array("+options_php_array+"))"
+		options_php_array_string = "['values' => ["+options_php_array+"]]"
 
 		attribute_code = extra_params.get('attribute_code', None)
 		if not attribute_code:
@@ -114,11 +114,20 @@ class ProductAttributeSnippet(Snippet):
 		with open(templatePath, 'rb') as tmpl:
 			template = tmpl.read().decode('utf-8')
 
+		is_swatch_option = frontend_input == 'swatch_visual' or frontend_input == 'swatch_text'
+
+		if frontend_input == 'swatch_visual':
+			options_php_array_string = "['values' => ['Black' => '#000000', 'White' => '#ffffff']]"
+		elif frontend_input == 'swatch_text' :
+			options_php_array_string = "['values' => ['Sample' => 'Sample']]"
+		else:
+			options_php_array_string = options_php_array_string
+
 		methodBody = template.format(
 			attribute_code=attribute_code,
 			attribute_label=attribute_label,
 			value_type=value_type,
-			frontend_input=frontend_input,
+			frontend_input= frontend_input if not is_swatch_option else 'select',
 			user_defined = user_defined,
 			scope = scope,
 			required = str(required).lower(),
@@ -133,35 +142,81 @@ class ProductAttributeSnippet(Snippet):
 			is_visible_in_advanced_search = extra_params.get('is_visible_in_advanced_search','0'),
 			apply_to = apply_to,
 			backend = 'Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend' if frontend_input == 'multiselect' else '',
-			source_model = source_model
+			source_model = source_model,
+			call_convert_method = '$this->convert' + upperfirst(attribute_code) + 'ToSwatches();' if is_swatch_option else ''
 		)
 
 		setupType = 'Install'
 		if upgrade_data:
 			setupType = 'Upgrade'
 
-		install_data = Phpclass('Setup\\{}Data'.format(setupType),
-			implements=['{}DataInterface'.format(setupType)],
-			dependencies=[
-				'Magento\\Framework\\Setup\\{}DataInterface'.format(setupType),
-				'Magento\\Framework\\Setup\\ModuleContextInterface',
-				'Magento\\Framework\\Setup\\ModuleDataSetupInterface',
-				'Magento\\Eav\\Setup\\EavSetup',
-				'Magento\\Eav\\Setup\\EavSetupFactory'],
-			attributes=['private $eavSetupFactory;'])
+		if not is_swatch_option:
+			install_data = Phpclass('Setup\\{}Data'.format(setupType),
+				implements=['{}DataInterface'.format(setupType)],
+				dependencies=[
+					'Magento\\Framework\\Setup\\{}DataInterface'.format(setupType),
+					'Magento\\Framework\\Setup\\ModuleContextInterface',
+					'Magento\\Framework\\Setup\\ModuleDataSetupInterface',
+					'Magento\\Eav\\Setup\\EavSetup',
+					'Magento\\Eav\\Setup\\EavSetupFactory'],
+				attributes=['private $eavSetupFactory;'])
+		else:
+			install_data = Phpclass(
+				'Setup\\{}Data'.format(setupType),
+				implements=['{}DataInterface'.format(setupType)],
+				dependencies=[
+					'Magento\\Framework\\Setup\\{}DataInterface'.format(setupType),
+					'Magento\\Framework\\Setup\\ModuleContextInterface',
+					'Magento\\Framework\\Setup\\ModuleDataSetupInterface',
+					'Magento\\Eav\\Setup\\EavSetup',
+					'Magento\\Eav\\Setup\\EavSetupFactory',
+					'Magento\\Catalog\\Model\\ResourceModel\\Eav\\Attribute as eavAttribute'
+				],
+				attributes=[
+					"private $eavSetupFactory;",
+					"protected $optionCollection = [];",
+					"protected $colorMap = ['Black' => '#000000', 'White' => '#ffffff'];",
+					"protected $attrOptionCollectionFactory;",
+					"protected $eavConfig;"
+				]
+			)
 
-		install_data.add_method(Phpmethod(
-			'__construct',
-			params=[
-				'EavSetupFactory $eavSetupFactory',
-			],
-			body="$this->eavSetupFactory = $eavSetupFactory;",
-			docstring=[
-				'Constructor',
-				'',
-				'@param \\Magento\\Eav\\Setup\\EavSetupFactory $eavSetupFactory'
-			]
-		)) 
+		if not is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'__construct',
+				params=[
+					'EavSetupFactory $eavSetupFactory',
+				],
+				body="$this->eavSetupFactory = $eavSetupFactory;",
+				docstring=[
+					'Constructor',
+					'',
+					'@param \\Magento\\Eav\\Setup\\EavSetupFactory $eavSetupFactory'
+				]
+			))
+		else:
+			install_data.add_method(Phpmethod(
+				'__construct',
+				params=[
+					'EavSetupFactory $eavSetupFactory',
+					'\\Magento\\Eav\\Model\\ResourceModel\\Entity\\Attribute\\Option\\CollectionFactory $attrOptionCollectionFactory',
+					'\\Magento\\Eav\\Model\\Config $eavConfig'
+				],
+				body="""
+				$this->eavSetupFactory = $eavSetupFactory;
+				$this->attrOptionCollectionFactory = $attrOptionCollectionFactory;
+				$this->eavConfig = $eavConfig;
+				""",
+				docstring=[
+					'Constructor',
+					'',
+					'@param \\Magento\\Eav\\Setup\\EavSetupFactory $eavSetupFactory',
+					'@param \\Magento\\Eav\\Model\\ResourceModel\\Entity\\Attribute\\Option\\CollectionFactory $attrOptionCollectionFactory',
+					'@param \\Magento\\Eav\\Model\\Config $eavConfig',
+				]
+			))
+
+
 		install_data.add_method(Phpmethod('{}'.format(setupType.lower()),
 			params=['ModuleDataSetupInterface $setup','ModuleContextInterface $context'],
 			body="$eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);",
@@ -175,7 +230,164 @@ class ProductAttributeSnippet(Snippet):
 				params=['ModuleDataSetupInterface $setup','ModuleContextInterface $context'],
 				body = methodBody))
 
-			# Catalog Attributes XML | Transport Attribute to Quote Item Product
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'convert{}ToSwatches'.format(upperfirst(attribute_code)),
+				body="""$attribute = $this->eavConfig->getAttribute('catalog_product', '{attribute_code}');
+				if (!$attribute) {{
+				    return;
+				}}
+				$attributeData['option'] = $this->addExistingOptions($attribute);
+				$attributeData['frontend_input'] = 'select';
+				$attributeData['swatch_input_type'] = '{visual_type}';
+				$attributeData['update_product_preview_image'] = 1;
+				$attributeData['use_product_image_for_swatch'] = 0;
+				$attributeData['{key_option}'] = $this->getOptionSwatch($attributeData);
+				$attributeData['{key_default}'] = $this->{get_default_option}($attributeData);
+				$attributeData['{key_swatch}'] = $this->{get_option_swatch}($attributeData);
+				$attribute->addData($attributeData);
+				$attribute->save();
+				""".format(
+					attribute_code=attribute_code,
+					visual_type = 'visual' if frontend_input == 'swatch_visual' else 'text',
+					key_option = 'optionvisual' if frontend_input == 'swatch_visual' else 'optiontext',
+					key_default = 'defaultvisual' if frontend_input == 'swatch_visual' else 'defaulttext',
+					key_swatch = 'swatchvisual' if frontend_input == 'swatch_visual' else 'swatchtext',
+					get_default_option = 'getOptionDefaultVisual' if frontend_input == 'swatch_visual' else 'getOptionDefaultText',
+					get_option_swatch = 'getOptionSwatchVisual' if frontend_input == 'swatch_visual' else 'getOptionSwatchText',
+				),
+				docstring=[
+					'Convert {} to swatches'.format(attribute_code)
+				]
+			))
+
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'getOptionSwatch',
+				params=['array $attributeData'],
+				body="""$optionSwatch = ['order' => [], 'value' => [], 'delete' => []];
+				$i = 0;
+				foreach ($attributeData['option'] as $optionKey => $optionValue) {
+				    $optionSwatch['delete'][$optionKey] = '';
+				    $optionSwatch['order'][$optionKey] = (string)$i++;
+				    $optionSwatch['value'][$optionKey] = [$optionValue, ''];
+				}
+				return $optionSwatch;
+				""",
+				docstring=[
+					'@param array $attributeData',
+					'@return array'
+				]
+			))
+
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'getOptionSwatchVisual',
+				access='private',
+				params=['array $attributeData'],
+				body="""$optionSwatch = ['value' => []];
+				foreach ($attributeData['option'] as $optionKey => $optionValue) {
+				    if (substr($optionValue, 0, 1) == '#' && strlen($optionValue) == 7) {
+				        $optionSwatch['value'][$optionKey] = $optionValue;
+				    } else if ($this->colorMap[$optionValue]) {
+				        $optionSwatch['value'][$optionKey] = $this->colorMap[$optionValue];
+				    } else {
+				        $optionSwatch['value'][$optionKey] = $this->colorMap['White'];
+				    }
+				}
+				return $optionSwatch;
+				""",
+				docstring=[
+					'@param array $attributeData',
+					'@return array'
+				]
+			))
+
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'getOptionDefaultVisual',
+				access='private',
+				params=['array $attributeData'],
+				body="""$optionSwatch = $this->getOptionSwatchVisual($attributeData);
+				return [array_keys($optionSwatch['value'])[0]];
+				""",
+				docstring=[
+					'@param array $attributeData',
+					'@return array'
+				]
+			))
+
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'getOptionSwatchText',
+				access='private',
+				params=['array $attributeData'],
+				body="""$optionSwatch = ['value' => []];
+				foreach ($attributeData['option'] as $optionKey => $optionValue) {
+				    $optionSwatch['value'][$optionKey] = [$optionValue, ''];
+				}
+				return $optionSwatch;
+				""",
+				docstring=[
+					'@param array $attributeData',
+					'@return array'
+				]
+			))
+
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'getOptionDefaultText',
+				access='private',
+				params=['array $attributeData'],
+				body="""$optionSwatch = $this->getOptionSwatchText($attributeData);
+				return [array_keys($optionSwatch['value'])[0]];
+				""",
+				docstring=[
+					'@param array $attributeData',
+					'@return array'
+				]
+			))
+
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'loadOptionCollection',
+				access='private',
+				params=['$attributeId'],
+				body="""if (empty($this->optionCollection[$attributeId])) {
+				    $this->optionCollection[$attributeId] = $this->attrOptionCollectionFactory->create()
+				        ->setAttributeFilter($attributeId)
+				        ->setPositionOrder('asc', true)
+				        ->load();
+				}
+				""",
+				docstring=[
+					'@param $attributeId',
+					'@return void'
+				]
+			))
+
+		if is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'addExistingOptions',
+				access='private',
+				params=['eavAttribute $attribute'],
+				body="""$options = [];
+				$attributeId = $attribute->getId();
+				if ($attributeId) {
+				    $this->loadOptionCollection($attributeId);
+				    /** @var \Magento\Eav\Model\Entity\Attribute\Option $option */
+				    foreach ($this->optionCollection[$attributeId] as $option) {
+				        $options[$option->getId()] = $option->getValue();
+				    }
+				}
+				return $options;
+				""",
+				docstring=[
+					'@param eavAttribute $attribute',
+					'@return array'
+				]
+			))
+		# Catalog Attributes XML | Transport Attribute to Quote Item Product
 		transport_to_quote_item = extra_params.get('transport_to_quote_item', False)
 		if transport_to_quote_item:
 			config = Xmlnode('config', attributes={'xmlns:xsi':'http://www.w3.org/2001/XMLSchema-instance','xsi:noNamespaceSchemaLocation':"urn:magento:module:Magento_Catalog:etc/catalog_attributes.xsd"}, nodes=[

--- a/mage2gen/snippets/productattribute.py
+++ b/mage2gen/snippets/productattribute.py
@@ -154,17 +154,7 @@ class ProductAttributeSnippet(Snippet):
 		if upgrade_data:
 			setupType = 'Upgrade'
 
-		if not is_swatch_option:
-			install_data = Phpclass('Setup\\{}Data'.format(setupType),
-				implements=['{}DataInterface'.format(setupType)],
-				dependencies=[
-					'Magento\\Framework\\Setup\\{}DataInterface'.format(setupType),
-					'Magento\\Framework\\Setup\\ModuleContextInterface',
-					'Magento\\Framework\\Setup\\ModuleDataSetupInterface',
-					'Magento\\Eav\\Setup\\EavSetup',
-					'Magento\\Eav\\Setup\\EavSetupFactory'],
-				attributes=['private $eavSetupFactory;'])
-		else:
+		if is_swatch_option:
 			install_data = Phpclass(
 				'Setup\\{}Data'.format(setupType),
 				implements=['{}DataInterface'.format(setupType)],
@@ -184,8 +174,36 @@ class ProductAttributeSnippet(Snippet):
 					"protected $eavConfig;"
 				]
 			)
-
-		if not is_swatch_option:
+			install_data.add_method(Phpmethod(
+				'__construct',
+				params=[
+					'EavSetupFactory $eavSetupFactory',
+					'\\Magento\\Eav\\Model\\ResourceModel\\Entity\\Attribute\\Option\\CollectionFactory $attrOptionCollectionFactory',
+					'\\Magento\\Eav\\Model\\Config $eavConfig'
+				],
+				body="""
+					$this->eavSetupFactory = $eavSetupFactory;
+					$this->attrOptionCollectionFactory = $attrOptionCollectionFactory;
+					$this->eavConfig = $eavConfig;
+					""",
+				docstring=[
+					'Constructor',
+					'',
+					'@param \\Magento\\Eav\\Setup\\EavSetupFactory $eavSetupFactory',
+					'@param \\Magento\\Eav\\Model\\ResourceModel\\Entity\\Attribute\\Option\\CollectionFactory $attrOptionCollectionFactory',
+					'@param \\Magento\\Eav\\Model\\Config $eavConfig',
+				]
+			))
+		else:
+			install_data = Phpclass('Setup\\{}Data'.format(setupType),
+				implements=['{}DataInterface'.format(setupType)],
+				dependencies=[
+					'Magento\\Framework\\Setup\\{}DataInterface'.format(setupType),
+					'Magento\\Framework\\Setup\\ModuleContextInterface',
+					'Magento\\Framework\\Setup\\ModuleDataSetupInterface',
+					'Magento\\Eav\\Setup\\EavSetup',
+					'Magento\\Eav\\Setup\\EavSetupFactory'],
+				attributes=['private $eavSetupFactory;'])
 			install_data.add_method(Phpmethod(
 				'__construct',
 				params=[
@@ -198,28 +216,6 @@ class ProductAttributeSnippet(Snippet):
 					'@param \\Magento\\Eav\\Setup\\EavSetupFactory $eavSetupFactory'
 				]
 			))
-		else:
-			install_data.add_method(Phpmethod(
-				'__construct',
-				params=[
-					'EavSetupFactory $eavSetupFactory',
-					'\\Magento\\Eav\\Model\\ResourceModel\\Entity\\Attribute\\Option\\CollectionFactory $attrOptionCollectionFactory',
-					'\\Magento\\Eav\\Model\\Config $eavConfig'
-				],
-				body="""
-				$this->eavSetupFactory = $eavSetupFactory;
-				$this->attrOptionCollectionFactory = $attrOptionCollectionFactory;
-				$this->eavConfig = $eavConfig;
-				""",
-				docstring=[
-					'Constructor',
-					'',
-					'@param \\Magento\\Eav\\Setup\\EavSetupFactory $eavSetupFactory',
-					'@param \\Magento\\Eav\\Model\\ResourceModel\\Entity\\Attribute\\Option\\CollectionFactory $attrOptionCollectionFactory',
-					'@param \\Magento\\Eav\\Model\\Config $eavConfig',
-				]
-			))
-
 
 		install_data.add_method(Phpmethod('{}'.format(setupType.lower()),
 			params=['ModuleDataSetupInterface $setup','ModuleContextInterface $context'],
@@ -234,6 +230,7 @@ class ProductAttributeSnippet(Snippet):
 				params=['ModuleDataSetupInterface $setup','ModuleContextInterface $context'],
 				body = methodBody))
 
+		# Swatches Converter | \Magento\SwatchesSampleData\Model\Swatches
 		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'convert{}ToSwatches'.format(attribute_code_capitalized),
@@ -264,8 +261,6 @@ class ProductAttributeSnippet(Snippet):
 					'Convert {} to swatches'.format(attribute_code)
 				]
 			))
-
-		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'getOptionSwatch',
 				params=['array $attributeData'],
@@ -283,8 +278,6 @@ class ProductAttributeSnippet(Snippet):
 					'@return array'
 				]
 			))
-
-		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'getOptionSwatchVisual',
 				access='private',
@@ -306,8 +299,6 @@ class ProductAttributeSnippet(Snippet):
 					'@return array'
 				]
 			))
-
-		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'getOptionDefaultVisual',
 				access='private',
@@ -320,8 +311,6 @@ class ProductAttributeSnippet(Snippet):
 					'@return array'
 				]
 			))
-
-		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'getOptionSwatchText',
 				access='private',
@@ -337,8 +326,6 @@ class ProductAttributeSnippet(Snippet):
 					'@return array'
 				]
 			))
-
-		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'getOptionDefaultText',
 				access='private',
@@ -351,8 +338,6 @@ class ProductAttributeSnippet(Snippet):
 					'@return array'
 				]
 			))
-
-		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'loadOptionCollection',
 				access='private',
@@ -369,8 +354,6 @@ class ProductAttributeSnippet(Snippet):
 					'@return void'
 				]
 			))
-
-		if is_swatch_option:
 			install_data.add_method(Phpmethod(
 				'addExistingOptions',
 				access='private',

--- a/mage2gen/templates/attributes/productattribute.tmpl
+++ b/mage2gen/templates/attributes/productattribute.tmpl
@@ -26,3 +26,5 @@ $eavSetup->addAttribute(
         'option' => {options}
     ]
 );
+
+{call_convert_method}


### PR DESCRIPTION
This patch will add **swatch_visual** and **swatch_text** to current product attribute snippet.

+ Default value for color swatch

        'Black' => '#000000', 'White' => '#ffffff'

+ Default value for text swatch

        'Sample' => 'Sample'