### PR TITLE
[BUGFIX] Incorrect schema Query identifier used

### DIFF
--- a/mage2gen/snippets/graphql.py
+++ b/mage2gen/snippets/graphql.py
@@ -57,7 +57,7 @@ class GraphQlSnippet(Snippet):
 
             base_object_type.add_objectitem(
                 GraphQlObjectItem(
-                    identifier,
+                    item_identifier,
                     item_arguments=object_arguments,
                     item_type=item_type,
                     item_resolver=resolver_graphqlformat,


### PR DESCRIPTION
The generated code can't be used as the Query definition references the lower case type name

```
type Query {   
    posts (..)
}
```

When the main Type definition is uppercase first
```
type Posts {
    ...
}
```

Results in 
```
1 exception(s):
Exception #0 (GraphQL\Error\Error): Type "posts" not found in document.
```