### PR TITLE
[BUGFIX] Incorrect GraphQl schema Query Type identifier used

### DIFF
--- a/mage2gen/snippets/graphql.py
+++ b/mage2gen/snippets/graphql.py
@@ -57,7 +57,7 @@ class GraphQlSnippet(Snippet):
 
             base_object_type.add_objectitem(
                 GraphQlObjectItem(
-                    identifier,
+                    item_identifier,
                     item_arguments=object_arguments,
                     item_type=item_type,
                     item_resolver=resolver_graphqlformat,

--- a/mage2gen/snippets/graphql.py
+++ b/mage2gen/snippets/graphql.py
@@ -45,8 +45,11 @@ class GraphQlSnippet(Snippet):
                                                                           item_identifier)
 
         item_type = 'String'
-        if base_type != 'Mutation':
+        if base_type == 'Custom':
             item_type = identifier
+        
+        if base_type == 'Query':
+            item_type = item_identifier
 
         schema = GraphQlSchema()
 
@@ -57,7 +60,7 @@ class GraphQlSnippet(Snippet):
 
             base_object_type.add_objectitem(
                 GraphQlObjectItem(
-                    item_identifier,
+                    identifier,
                     item_arguments=object_arguments,
                     item_type=item_type,
                     item_resolver=resolver_graphqlformat,


### PR DESCRIPTION
The generated code can't be used as the Query definition references the lower case type name

```
type Query {
    
    posts (
        ...
    ): posts  @resolver(...

}
```

When the main Type definition is uppercase first
```
type Posts {
    ...
}
```

Results in 
```
1 exception(s):
Exception #0 (GraphQL\Error\Error): Type "posts" not found in document.
```

Fixed by passing the item_type param for Query types as the uppercasefirst item_identifier resulting in 

```
type Query {
    
    posts (
        ...
    ): Posts  @resolver(

}
```