### PR TITLE
Proper fallback for creating an around plugin.

### DIFF
--- a/mage2gen/snippets/plugin.py
+++ b/mage2gen/snippets/plugin.py
@@ -104,12 +104,16 @@ class PluginSnippet(Snippet):
 			try:
 				data = self.get_mage2methods()
 				parameters = data[methodname][classname]
-				for key, value in parameters.items():
-					param = '$' + key
-					returnParams.append(param)
-					if value != '':
-						param += ' = ' + value
-					params.append(param)
+				if(parameters)
+					for key, value in parameters.items():
+						param = '$' + key
+						returnParams.append(param)
+						if value != '':
+							param += ' = ' + value
+						params.append(param)
+				else:
+					params.append('...$args')
+					returnParams.append('...$args')
 			except KeyError:
 				pass
 		else:


### PR DESCRIPTION
When there are no arguments found for certain method of an around plugin, just pass the arguments using the splat operator. (makes the plugin work on non magento classes)