### PR TITLE
Make a customer attribute visible in backend by default

### DIFF
--- a/mage2gen/templates/attributes/customerattribute.tmpl
+++ b/mage2gen/templates/attributes/customerattribute.tmpl
@@ -10,6 +10,10 @@ $customerSetup->addAttribute(
         'visible' => {visible},
         'position' => {sort_order},
         'system' => false,
-        'backend' => '{backend_model}'
+        'backend' => '{backend_model}',
+        'is_used_in_grid' => 1,
+        'is_visible_in_grid' => 1,
+        'is_filterable_in_grid' => 1,
+        'is_searchable_in_grid' => 1
     ]
 );


### PR DESCRIPTION
Make a customer attribute visible in backend by default, now it is hidden which can be confusing.