### PR TITLE
Entity ID field should be unsigned

### DIFF
--- a/mage2gen/snippets/model.py
+++ b/mage2gen/snippets/model.py
@@ -111,7 +111,7 @@ class ModelSnippet(Snippet):
 			'xsi:type': "{}".format('smallint'),
 			'name': "{}".format(model_id),
 			'padding': "{}".format('6'),
-			'unsigned': "{}".format('false'),
+			'unsigned': "{}".format('true'),
 			'nullable': "{}".format('false'),
 			'identity': "{}".format('true'),
 			'comment': "{}".format('Entity Id')
@@ -153,7 +153,7 @@ class ModelSnippet(Snippet):
 			attributes['length'] = '255'
 
 
-		# Create di.xml preferences
+		# Create db_schema.xml declaration
 		self.add_xml('etc/db_schema.xml', Xmlnode('schema', attributes={
 			'xsi:noNamespaceSchemaLocation': "urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd"}, nodes=[
 			Xmlnode('table', attributes={
@@ -166,7 +166,7 @@ class ModelSnippet(Snippet):
 					'xsi:type': "{}".format('smallint'),
 					'name': "{}".format(model_id),
 					'padding': "{}".format('6'),
-					'unsigned': "{}".format('false'),
+					'unsigned': "{}".format('true'),
 					'nullable': "{}".format('false'),
 					'identity': "{}".format('true'),
 					'comment': "{}".format('Entity Id')


### PR DESCRIPTION
## Expected result

`db_schema.xml` built with `Entity ID` attribute `unsigned` value `true`

```xml
<?xml version="1.0" ?>
<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
	<table comment="m2coach_storelocator_store Table" engine="innodb" name="m2coach_storelocator_store" resource="default">
		<column comment="Entity Id" identity="true" name="store_id" nullable="false" padding="6" unsigned="true" xsi:type="smallint"/>
		<constraint referenceId="PRIMARY" xsi:type="primary">
			<column name="store_id"/>
		</constraint>
		<column identity="false" name="id" nullable="false" xsi:type="int"/>
	</table>
</schema>
```

## Actual result

```xml
<?xml version="1.0" ?>
<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
	<table comment="m2coach_storelocator_store Table" engine="innodb" name="m2coach_storelocator_store" resource="default">
		<column comment="Entity Id" identity="true" name="store_id" nullable="false" padding="6" unsigned="false" xsi:type="smallint"/>
		<constraint referenceId="PRIMARY" xsi:type="primary">
			<column name="store_id"/>
		</constraint>
		<column identity="false" name="id" nullable="false" xsi:type="int"/>
	</table>
</schema>
```