### PR TITLE
Follow Magento Coding standards

### DIFF
--- a/mage2gen/templates/class.tmpl
+++ b/mage2gen/templates/class.tmpl
@@ -3,11 +3,7 @@
 
 namespace {namespace};
 {dependencies}
-/**
- * Class {class_name}
- *
- * @package {namespace}
- */
+
 {abstract}class {class_name}{extends}{implements}
 {{
 {attributes}{methods}

--- a/mage2gen/templates/class.tmpl
+++ b/mage2gen/templates/class.tmpl
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 {license}
 
 namespace {namespace};

--- a/mage2gen/templates/interface.tmpl
+++ b/mage2gen/templates/interface.tmpl
@@ -1,13 +1,9 @@
-<?php
+<?php declare(strict_types=1);
 {license}
 
 namespace {namespace};
 {dependencies}
-/**
- * Interface {class_name}
- *
- * @package {namespace}
- */
+
 interface {class_name}{extends}{implements}
 {{
 {attributes}{methods}


### PR DESCRIPTION
Context: https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html

1. `@author ,@category, @package, and @subpackage MUST NOT be used. Documentation is organized with the use of namespaces.`
1. Classes and interfaces should have a short description with a human-readable description of the class. If the short description adds no additional information beyond what the type name already supplies, the short description must be omitted.

Also - we live in the age of `strict_types` - so I introduced strict types to all new classes.